### PR TITLE
Updated Java date objects to be strings to avoid parsing errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.lockstep</groupId>
     <artifactId>lockstepsdk</artifactId>
-    <version>2022.2.93.0</version>
+    <version>2022.3.26.0</version>
  
     <name>lockstep-sdk-java</name>
     <description>Java sample project for Lockstep SDK</description>

--- a/src/main/java/io/lockstep/api/LockstepApi.java
+++ b/src/main/java/io/lockstep/api/LockstepApi.java
@@ -8,7 +8,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2.93.0
+ * @version    2022.3.26.0
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/ActivitiesClient.java
+++ b/src/main/java/io/lockstep/api/clients/ActivitiesClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
@@ -47,7 +47,7 @@ public class ActivitiesClient
      * An Activity contains information about work being done on a specific accounting task. You can use Activities to track information about who has been assigned a specific task, the current status of the task, the name and description given for the particular task, the priority of the task, and any amounts collected, paid, or credited for the task.
      *
      * @param id The unique Lockstep Platform ID number of this Activity
-     * @param include To fetch additional data on this object, specify the list of elements to retrieve. Available collections: Company, Attachments, CustomFields, and Notes
+     * @param include To fetch additional data on this object, specify the list of elements to retrieve. Available collections: Company, Attachments, CustomFields, Notes, References, and UserAssignedToName
      * @return A {@link io.lockstep.api.models.LockstepResponse} containing the results
      */
     public LockstepResponse<ActivityModel> retrieveActivity(String id, String include)
@@ -115,7 +115,7 @@ public class ActivitiesClient
      * An Activity contains information about work being done on a specific accounting task. You can use Activities to track information about who has been assigned a specific task, the current status of the task, the name and description given for the particular task, the priority of the task, and any amounts collected, paid, or credited for the task.
      *
      * @param filter The filter for this query. See [Searchlight Query Language](https://developer.lockstep.io/docs/querying-with-searchlight)
-     * @param include To fetch additional data on this object, specify the list of elements to retrieve. Available collections: Company, Attachments, CustomFields, and Notes
+     * @param include To fetch additional data on this object, specify the list of elements to retrieve. Available collections: Company, Attachments, CustomFields, Notes, References, and UserAssignedToName
      * @param order The sort order for this query. See See [Searchlight Query Language](https://developer.lockstep.io/docs/querying-with-searchlight)
      * @param pageSize The page size for results (default 200). See [Searchlight Query Language](https://developer.lockstep.io/docs/querying-with-searchlight)
      * @param pageNumber The page number for results (default 0). See [Searchlight Query Language](https://developer.lockstep.io/docs/querying-with-searchlight)
@@ -145,5 +145,22 @@ public class ActivitiesClient
         RestRequest<ActivityStreamItemModel[]> r = new RestRequest<ActivityStreamItemModel[]>(this.client, "GET", "/api/v1/Activities/{id}/stream");
         r.AddPath("{id}", id.toString());
         return r.Call(ActivityStreamItemModel[].class);
+    }
+
+    /**
+     * Forwards an activity by creating a new activity with all child references and assigning the new activity to a new user.
+     *
+     * An Activity contains information about work being done on a specific accounting task. You can use Activities to track information about who has been assigned a specific task, the current status of the task, the name and description given for the particular task, the priority of the task, and any amounts collected, paid, or credited for the task.
+     *
+     * @param activityId
+     * @param userId
+     * @return A {@link io.lockstep.api.models.LockstepResponse} containing the results
+     */
+    public LockstepResponse<ActivityModel> forwardActivity(String activityId, String userId)
+    {
+        RestRequest<ActivityModel> r = new RestRequest<ActivityModel>(this.client, "POST", "/api/v1/Activities/{activityId}/forward/{userId}");
+        r.AddPath("{activityId}", activityId.toString());
+        r.AddPath("{userId}", userId.toString());
+        return r.Call(ActivityModel.class);
     }
 }

--- a/src/main/java/io/lockstep/api/clients/ApiKeysClient.java
+++ b/src/main/java/io/lockstep/api/clients/ApiKeysClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/AppEnrollmentsClient.java
+++ b/src/main/java/io/lockstep/api/clients/AppEnrollmentsClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
@@ -50,7 +50,7 @@ public class AppEnrollmentsClient
      * See [Applications and Enrollments](https://developer.lockstep.io/docs/applications-and-enrollments) for more information.
      *
      * @param id The unique ID number of the App Enrollment to retrieve
-     * @param include To fetch additional data on this object, specify the list of elements to retrieve. Available collections: App, CustomFields
+     * @param include To fetch additional data on this object, specify the list of elements to retrieve. Available collections: App, CustomFields, LastSync, LastSuccessfulSync
      * @return A {@link io.lockstep.api.models.LockstepResponse} containing the results
      */
     public LockstepResponse<AppEnrollmentModel> retrieveAppEnrollment(String id, String include)
@@ -126,7 +126,7 @@ public class AppEnrollmentsClient
      * See [Applications and Enrollments](https://developer.lockstep.io/docs/applications-and-enrollments) for more information.
      *
      * @param filter The filter for this query. See [Searchlight Query Language](https://developer.lockstep.io/docs/querying-with-searchlight)
-     * @param include To fetch additional data on this object, specify the list of elements to retrieve. Available collections: App, CustomFields, LastSync
+     * @param include To fetch additional data on this object, specify the list of elements to retrieve. Available collections: App, CustomFields, LastSync, LastSuccessfulSync
      * @param order The sort order for this query. See See [Searchlight Query Language](https://developer.lockstep.io/docs/querying-with-searchlight)
      * @param pageSize The page size for results (default 200). See [Searchlight Query Language](https://developer.lockstep.io/docs/querying-with-searchlight)
      * @param pageNumber The page number for results (default 0). See [Searchlight Query Language](https://developer.lockstep.io/docs/querying-with-searchlight)

--- a/src/main/java/io/lockstep/api/clients/ApplicationsClient.java
+++ b/src/main/java/io/lockstep/api/clients/ApplicationsClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/AttachmentsClient.java
+++ b/src/main/java/io/lockstep/api/clients/AttachmentsClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/CodeDefinitionsClient.java
+++ b/src/main/java/io/lockstep/api/clients/CodeDefinitionsClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/CompaniesClient.java
+++ b/src/main/java/io/lockstep/api/clients/CompaniesClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/ContactsClient.java
+++ b/src/main/java/io/lockstep/api/clients/ContactsClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/CreditMemoAppliedClient.java
+++ b/src/main/java/io/lockstep/api/clients/CreditMemoAppliedClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/CurrenciesClient.java
+++ b/src/main/java/io/lockstep/api/clients/CurrenciesClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
@@ -21,7 +21,6 @@ import io.lockstep.api.RestRequest;
 import io.lockstep.api.models.LockstepResponse;
 import io.lockstep.api.models.CurrencyRateModel;
 
-import java.util.Date;
 import io.lockstep.api.models.BulkCurrencyConversionModel;
 
 /**
@@ -51,7 +50,7 @@ public class CurrenciesClient
      * @param dataProvider Optionally, you can specify a data provider.
      * @return A {@link io.lockstep.api.models.LockstepResponse} containing the results
      */
-    public LockstepResponse<CurrencyRateModel> retrievecurrencyrate(String sourceCurrency, String destinationCurrency, Date date, String dataProvider)
+    public LockstepResponse<CurrencyRateModel> retrievecurrencyrate(String sourceCurrency, String destinationCurrency, String date, String dataProvider)
     {
         RestRequest<CurrencyRateModel> r = new RestRequest<CurrencyRateModel>(this.client, "GET", "/api/v1/Currencies/{sourceCurrency}/{destinationCurrency}");
         r.AddPath("{sourceCurrency}", sourceCurrency.toString());

--- a/src/main/java/io/lockstep/api/clients/CustomFieldDefinitionsClient.java
+++ b/src/main/java/io/lockstep/api/clients/CustomFieldDefinitionsClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/CustomFieldValuesClient.java
+++ b/src/main/java/io/lockstep/api/clients/CustomFieldValuesClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/DefinitionsClient.java
+++ b/src/main/java/io/lockstep/api/clients/DefinitionsClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/EmailsClient.java
+++ b/src/main/java/io/lockstep/api/clients/EmailsClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/InvoiceHistoryClient.java
+++ b/src/main/java/io/lockstep/api/clients/InvoiceHistoryClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/InvoicesClient.java
+++ b/src/main/java/io/lockstep/api/clients/InvoicesClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/LeadsClient.java
+++ b/src/main/java/io/lockstep/api/clients/LeadsClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/NotesClient.java
+++ b/src/main/java/io/lockstep/api/clients/NotesClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/PaymentApplicationsClient.java
+++ b/src/main/java/io/lockstep/api/clients/PaymentApplicationsClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/PaymentsClient.java
+++ b/src/main/java/io/lockstep/api/clients/PaymentsClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/ProvisioningClient.java
+++ b/src/main/java/io/lockstep/api/clients/ProvisioningClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
@@ -22,6 +22,8 @@ import io.lockstep.api.models.LockstepResponse;
 import io.lockstep.api.models.ProvisioningResponseModel;
 import io.lockstep.api.models.ProvisioningModel;
 import io.lockstep.api.models.ProvisioningFinalizeRequestModel;
+import io.lockstep.api.models.ActionResultModel;
+import io.lockstep.api.models.DeveloperAccountSubmitModel;
 
 /**
  * Contains all methods related to Provisioning
@@ -63,5 +65,17 @@ public class ProvisioningClient
         RestRequest<ProvisioningResponseModel> r = new RestRequest<ProvisioningResponseModel>(this.client, "POST", "/api/v1/Provisioning/finalize");
         r.AddBody(body);
         return r.Call(ProvisioningResponseModel.class);
+    }
+
+    /**
+     *
+     * @param body
+     * @return A {@link io.lockstep.api.models.LockstepResponse} containing the results
+     */
+    public LockstepResponse<ActionResultModel> provisionFreeDeveloperAccount(DeveloperAccountSubmitModel body)
+    {
+        RestRequest<ActionResultModel> r = new RestRequest<ActionResultModel>(this.client, "POST", "/api/v1/Provisioning/free-account");
+        r.AddBody(body);
+        return r.Call(ActionResultModel.class);
     }
 }

--- a/src/main/java/io/lockstep/api/clients/ReportsClient.java
+++ b/src/main/java/io/lockstep/api/clients/ReportsClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
@@ -24,7 +24,6 @@ import io.lockstep.api.models.CashflowReportModel;
 import io.lockstep.api.models.DailySalesOutstandingReportModel;
 import io.lockstep.api.models.RiskRateModel;
 import io.lockstep.api.models.ArHeaderInfoModel;
-import java.util.Date;
 import io.lockstep.api.models.AgingModel;
 import io.lockstep.api.models.ArAgingHeaderInfoModel;
 import io.lockstep.api.models.AttachmentHeaderInfoModel;
@@ -93,7 +92,7 @@ public class ReportsClient
      * @param companyId Include a company to get AR data for a specific company, leave as null to include all Companies.
      * @return A {@link io.lockstep.api.models.LockstepResponse} containing the results
      */
-    public LockstepResponse<ArHeaderInfoModel> accountsReceivableHeader(Date reportDate, String companyId)
+    public LockstepResponse<ArHeaderInfoModel> accountsReceivableHeader(String reportDate, String companyId)
     {
         RestRequest<ArHeaderInfoModel> r = new RestRequest<ArHeaderInfoModel>(this.client, "GET", "/api/v1/Reports/ar-header");
         r.AddQuery("reportDate", reportDate.toString());

--- a/src/main/java/io/lockstep/api/clients/StatusClient.java
+++ b/src/main/java/io/lockstep/api/clients/StatusClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/SyncClient.java
+++ b/src/main/java/io/lockstep/api/clients/SyncClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/UserAccountsClient.java
+++ b/src/main/java/io/lockstep/api/clients/UserAccountsClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/clients/UserRolesClient.java
+++ b/src/main/java/io/lockstep/api/clients/UserRolesClient.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/ActivityModel.java
+++ b/src/main/java/io/lockstep/api/models/ActivityModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * An Activity contains information about work being done on a specific accounting task.
@@ -36,12 +35,12 @@ public class ActivityModel
     private Boolean isOpen;
     private String priority;
     private String userAssignedTo;
-    private Date dateAssigned;
-    private Date dateClosed;
-    private Date snoozeUntilDate;
-    private Date created;
+    private String dateAssigned;
+    private String dateClosed;
+    private String snoozeUntilDate;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
     private Double amountCollected;
     private Double amountPaid;
@@ -49,10 +48,12 @@ public class ActivityModel
     private Boolean isUnread;
     private Boolean isArchived;
     private CompanyModel company;
+    private String userAssignedToName;
     private AttachmentModel[] attachments;
     private NoteModel[] notes;
     private CustomFieldDefinitionModel[] customFieldDefinitions;
     private CustomFieldValueModel[] customFieldValues;
+    private ActivityXRefModel[] references;
 
     /**
      * The unique ID of this record, automatically assigned by Lockstep when this record is
@@ -193,25 +194,25 @@ public class ActivityModel
      *
      * @return The field dateAssigned
      */
-    public Date getDateAssigned() { return this.dateAssigned; }
+    public String getDateAssigned() { return this.dateAssigned; }
     /**
      * The date the activity was assigned.
      *
      * @param value The new value for dateAssigned
      */
-    public void setDateAssigned(Date value) { this.dateAssigned = value; }
+    public void setDateAssigned(String value) { this.dateAssigned = value; }
     /**
      * The date the activity was closed.
      *
      * @return The field dateClosed
      */
-    public Date getDateClosed() { return this.dateClosed; }
+    public String getDateClosed() { return this.dateClosed; }
     /**
      * The date the activity was closed.
      *
      * @param value The new value for dateClosed
      */
-    public void setDateClosed(Date value) { this.dateClosed = value; }
+    public void setDateClosed(String value) { this.dateClosed = value; }
     /**
      * If this activity has been "snoozed", this field will be non-null and will contain
      * the date when the activity will be displayed.  Until that date arrives, the activity
@@ -219,7 +220,7 @@ public class ActivityModel
      *
      * @return The field snoozeUntilDate
      */
-    public Date getSnoozeUntilDate() { return this.snoozeUntilDate; }
+    public String getSnoozeUntilDate() { return this.snoozeUntilDate; }
     /**
      * If this activity has been "snoozed", this field will be non-null and will contain
      * the date when the activity will be displayed.  Until that date arrives, the activity
@@ -227,19 +228,19 @@ public class ActivityModel
      *
      * @param value The new value for snoozeUntilDate
      */
-    public void setSnoozeUntilDate(Date value) { this.snoozeUntilDate = value; }
+    public void setSnoozeUntilDate(String value) { this.snoozeUntilDate = value; }
     /**
      * The date on which this activity was created.
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date on which this activity was created.
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The ID of the user who created this activity.
      *
@@ -257,13 +258,13 @@ public class ActivityModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * The date on which this activity was last modified.
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The ID of the user who last modified this activity.
      *
@@ -357,6 +358,18 @@ public class ActivityModel
      */
     public void setCompany(CompanyModel value) { this.company = value; }
     /**
+     * The name of the user the activity is assigned to
+     *
+     * @return The field userAssignedToName
+     */
+    public String getUserAssignedToName() { return this.userAssignedToName; }
+    /**
+     * The name of the user the activity is assigned to
+     *
+     * @param value The new value for userAssignedToName
+     */
+    public void setUserAssignedToName(String value) { this.userAssignedToName = value; }
+    /**
      * All attachments attached to applied activity.
      *
      * To retrieve this collection, specify `Attachments` in the "Include" parameter for your query.
@@ -420,4 +433,20 @@ public class ActivityModel
      * @param value The new value for customFieldValues
      */
     public void setCustomFieldValues(CustomFieldValueModel[] value) { this.customFieldValues = value; }
+    /**
+     * All references attached to this applied activity.
+     *
+     * To retrieve this collection, specify `References` in the "Include" parameter for your query.
+     *
+     * @return The field references
+     */
+    public ActivityXRefModel[] getReferences() { return this.references; }
+    /**
+     * All references attached to this applied activity.
+     *
+     * To retrieve this collection, specify `References` in the "Include" parameter for your query.
+     *
+     * @param value The new value for references
+     */
+    public void setReferences(ActivityXRefModel[] value) { this.references = value; }
 };

--- a/src/main/java/io/lockstep/api/models/ActivityStreamItemModel.java
+++ b/src/main/java/io/lockstep/api/models/ActivityStreamItemModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Represents an item belonging to the activity stream.
@@ -24,9 +23,9 @@ import java.util.Date;
 public class ActivityStreamItemModel
 {
     private String objectKey;
-    private String activityType;
+    private String activityStreamType;
     private String textValue;
-    private Date created;
+    private String created;
     private String createdUserId;
     private String groupKey;
     private String fromEmailAddress;
@@ -49,15 +48,15 @@ public class ActivityStreamItemModel
     /**
      * The type code of the activity stream item.
      *
-     * @return The field activityType
+     * @return The field activityStreamType
      */
-    public String getActivityType() { return this.activityType; }
+    public String getActivityStreamType() { return this.activityStreamType; }
     /**
      * The type code of the activity stream item.
      *
-     * @param value The new value for activityType
+     * @param value The new value for activityStreamType
      */
-    public void setActivityType(String value) { this.activityType = value; }
+    public void setActivityStreamType(String value) { this.activityStreamType = value; }
     /**
      * The text body description for this Activity Stream Item.
      *
@@ -75,13 +74,13 @@ public class ActivityStreamItemModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date on which this activity stream item was created.
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The ID of the user who created this activity.
      *

--- a/src/main/java/io/lockstep/api/models/ActivityXRefModel.java
+++ b/src/main/java/io/lockstep/api/models/ActivityXRefModel.java
@@ -1,0 +1,96 @@
+
+/**
+ * Lockstep Software Development Kit for Java
+ *
+ * (c) 2021-2022 Lockstep, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     Ted Spence <tspence@lockstep.io>
+ * @copyright  2021-2022 Lockstep, Inc.
+ * @version    2022.3
+ * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
+ */
+
+
+package io.lockstep.api.models;
+
+
+public class ActivityXRefModel
+{
+    private String activityXRefId;
+    private String activityId;
+    private String groupKey;
+    private String tableKey;
+    private String objectKey;
+
+    /**
+     * The unique ID of this record, automatically assigned by Lockstep when this is
+     * added to the Lockstep platform.
+     *
+     * @return The field activityXRefId
+     */
+    public String getActivityXRefId() { return this.activityXRefId; }
+    /**
+     * The unique ID of this record, automatically assigned by Lockstep when this is
+     * added to the Lockstep platform.
+     *
+     * @param value The new value for activityXRefId
+     */
+    public void setActivityXRefId(String value) { this.activityXRefId = value; }
+    /**
+     * The ID of the activity to which this reference belongs.
+     *
+     * @return The field activityId
+     */
+    public String getActivityId() { return this.activityId; }
+    /**
+     * The ID of the activity to which this reference belongs.
+     *
+     * @param value The new value for activityId
+     */
+    public void setActivityId(String value) { this.activityId = value; }
+    /**
+     * The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
+     * account will share the same GroupKey value.  GroupKey values cannot be changed once created.
+     *
+     * For more information, see [Accounts and GroupKeys](https://developer.lockstep.io/docs/accounts-and-groupkeys).
+     *
+     * @return The field groupKey
+     */
+    public String getGroupKey() { return this.groupKey; }
+    /**
+     * The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
+     * account will share the same GroupKey value.  GroupKey values cannot be changed once created.
+     *
+     * For more information, see [Accounts and GroupKeys](https://developer.lockstep.io/docs/accounts-and-groupkeys).
+     *
+     * @param value The new value for groupKey
+     */
+    public void setGroupKey(String value) { this.groupKey = value; }
+    /**
+     * The name of the table the activity reference is associated with
+     *
+     * @return The field tableKey
+     */
+    public String getTableKey() { return this.tableKey; }
+    /**
+     * The name of the table the activity reference is associated with
+     *
+     * @param value The new value for tableKey
+     */
+    public void setTableKey(String value) { this.tableKey = value; }
+    /**
+     * The ID of the object the activity reference is associated with
+     *
+     * @return The field objectKey
+     */
+    public String getObjectKey() { return this.objectKey; }
+    /**
+     * The ID of the object the activity reference is associated with
+     *
+     * @param value The new value for objectKey
+     */
+    public void setObjectKey(String value) { this.objectKey = value; }
+};

--- a/src/main/java/io/lockstep/api/models/AgingModel.java
+++ b/src/main/java/io/lockstep/api/models/AgingModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/ApiKeyModel.java
+++ b/src/main/java/io/lockstep/api/models/ApiKeyModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * An API Key is an authentication token that you may use with the Lockstep API.  Because API Keys
@@ -34,11 +33,11 @@ public class ApiKeyModel
     private String name;
     private String apiKey;
     private String keyPrefix;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date revoked;
+    private String revoked;
     private String revokedUserId;
-    private Date expires;
+    private String expires;
 
     /**
      * The unique identifier for the API key.
@@ -119,13 +118,13 @@ public class ApiKeyModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date the API key was created.
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The user that created the API key.
      *
@@ -143,13 +142,13 @@ public class ApiKeyModel
      *
      * @return The field revoked
      */
-    public Date getRevoked() { return this.revoked; }
+    public String getRevoked() { return this.revoked; }
     /**
      * The date the API key was revoked.
      *
      * @param value The new value for revoked
      */
-    public void setRevoked(Date value) { this.revoked = value; }
+    public void setRevoked(String value) { this.revoked = value; }
     /**
      * The user who revoked the API key.
      *
@@ -167,11 +166,11 @@ public class ApiKeyModel
      *
      * @return The field expires
      */
-    public Date getExpires() { return this.expires; }
+    public String getExpires() { return this.expires; }
     /**
      * The UTC datetime when the API key expires.
      *
      * @param value The new value for expires
      */
-    public void setExpires(Date value) { this.expires = value; }
+    public void setExpires(String value) { this.expires = value; }
 };

--- a/src/main/java/io/lockstep/api/models/AppEnrollmentCustomFieldModel.java
+++ b/src/main/java/io/lockstep/api/models/AppEnrollmentCustomFieldModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/AppEnrollmentModel.java
+++ b/src/main/java/io/lockstep/api/models/AppEnrollmentModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * An AppEnrollment represents an app that has been enrolled to the current account.  When you sign up for an
@@ -32,9 +31,9 @@ public class AppEnrollmentModel
     private String appId;
     private String groupKey;
     private Boolean isActive;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
     private String cronSettings;
     private Boolean syncScheduleIsActive;
@@ -42,6 +41,7 @@ public class AppEnrollmentModel
     private CustomFieldDefinitionModel[] customFieldDefinitions;
     private CustomFieldValueModel[] customFieldValues;
     private SyncRequestModel lastSync;
+    private SyncRequestModel lastSuccessfulSync;
     private ConnectorInfoModel connectorInfo;
 
     /**
@@ -107,13 +107,13 @@ public class AppEnrollmentModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * Created date
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * Created user ID
      *
@@ -131,13 +131,13 @@ public class AppEnrollmentModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * Last modified date
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * Last user ID to modify
      *
@@ -242,6 +242,18 @@ public class AppEnrollmentModel
      * @param value The new value for lastSync
      */
     public void setLastSync(SyncRequestModel value) { this.lastSync = value; }
+    /**
+     * Data about the last successful sync associated with this enrollment
+     *
+     * @return The field lastSuccessfulSync
+     */
+    public SyncRequestModel getLastSuccessfulSync() { return this.lastSuccessfulSync; }
+    /**
+     * Data about the last successful sync associated with this enrollment
+     *
+     * @param value The new value for lastSuccessfulSync
+     */
+    public void setLastSuccessfulSync(SyncRequestModel value) { this.lastSuccessfulSync = value; }
     /**
      * Optional data necessary to create an app enrollment for a supported connector.
      * Only enter relevant fields for the given connector.

--- a/src/main/java/io/lockstep/api/models/ApplicationModel.java
+++ b/src/main/java/io/lockstep/api/models/ApplicationModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * An Application represents a feature available to customers within the Lockstep Platform.  You can create
@@ -41,8 +40,8 @@ public class ApplicationModel
     private String priceTerms;
     private String createdUserId;
     private String modifiedUserId;
-    private Date created;
-    private Date modified;
+    private String created;
+    private String modified;
     private Boolean isActive;
     private String wikiURL;
     private String groupKey;
@@ -176,25 +175,25 @@ public class ApplicationModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date this application was created
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The date this application was last modified
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * The date this application was last modified
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * Flag indicating if the application is active.
      *

--- a/src/main/java/io/lockstep/api/models/ArAgingHeaderInfoModel.java
+++ b/src/main/java/io/lockstep/api/models/ArAgingHeaderInfoModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/ArHeaderInfoModel.java
+++ b/src/main/java/io/lockstep/api/models/ArHeaderInfoModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Aggregated Accounts Receivable information.
@@ -24,7 +23,7 @@ import java.util.Date;
 public class ArHeaderInfoModel
 {
     private String groupKey;
-    private Date reportPeriod;
+    private String reportPeriod;
     private Integer totalCustomers;
     private Integer totalInvoices;
     private Double totalInvoicedAmount;
@@ -68,13 +67,13 @@ public class ArHeaderInfoModel
      *
      * @return The field reportPeriod
      */
-    public Date getReportPeriod() { return this.reportPeriod; }
+    public String getReportPeriod() { return this.reportPeriod; }
     /**
      * The date of the report
      *
      * @param value The new value for reportPeriod
      */
-    public void setReportPeriod(Date value) { this.reportPeriod = value; }
+    public void setReportPeriod(String value) { this.reportPeriod = value; }
     /**
      * The total number of customers.
      *

--- a/src/main/java/io/lockstep/api/models/AtRiskInvoiceSummaryModel.java
+++ b/src/main/java/io/lockstep/api/models/AtRiskInvoiceSummaryModel.java
@@ -9,33 +9,32 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Contains summarized data for an invoice
  */
 public class AtRiskInvoiceSummaryModel
 {
-    private Date reportDate;
+    private String reportDate;
     private String groupKey;
     private String customerId;
     private String invoiceId;
     private String invoiceNumber;
-    private Date invoiceDate;
+    private String invoiceDate;
     private String customerName;
     private String status;
-    private Date paymentDueDate;
+    private String paymentDueDate;
     private Double invoiceAmount;
     private Double outstandingBalance;
     private String invoiceTypeCode;
-    private Date newestActivity;
+    private String newestActivity;
     private Integer daysPastDue;
     private String[] paymentNumbers;
     private String[] paymentIds;
@@ -45,13 +44,13 @@ public class AtRiskInvoiceSummaryModel
      *
      * @return The field reportDate
      */
-    public Date getReportDate() { return this.reportDate; }
+    public String getReportDate() { return this.reportDate; }
     /**
      * The date of the report
      *
      * @param value The new value for reportDate
      */
-    public void setReportDate(Date value) { this.reportDate = value; }
+    public void setReportDate(String value) { this.reportDate = value; }
     /**
      * The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
      * account will share the same GroupKey value.  GroupKey values cannot be changed once created.
@@ -113,13 +112,13 @@ public class AtRiskInvoiceSummaryModel
      *
      * @return The field invoiceDate
      */
-    public Date getInvoiceDate() { return this.invoiceDate; }
+    public String getInvoiceDate() { return this.invoiceDate; }
     /**
      * The reporting date for this invoice.
      *
      * @param value The new value for invoiceDate
      */
-    public void setInvoiceDate(Date value) { this.invoiceDate = value; }
+    public void setInvoiceDate(String value) { this.invoiceDate = value; }
     /**
      * The name of the counterparty for the invoice, for example, a customer or vendor.
      *
@@ -149,13 +148,13 @@ public class AtRiskInvoiceSummaryModel
      *
      * @return The field paymentDueDate
      */
-    public Date getPaymentDueDate() { return this.paymentDueDate; }
+    public String getPaymentDueDate() { return this.paymentDueDate; }
     /**
      * The due date of the invoice.
      *
      * @param value The new value for paymentDueDate
      */
-    public void setPaymentDueDate(Date value) { this.paymentDueDate = value; }
+    public void setPaymentDueDate(String value) { this.paymentDueDate = value; }
     /**
      * The total amount of the Invoice.
      *
@@ -197,13 +196,13 @@ public class AtRiskInvoiceSummaryModel
      *
      * @return The field newestActivity
      */
-    public Date getNewestActivity() { return this.newestActivity; }
+    public String getNewestActivity() { return this.newestActivity; }
     /**
      * The date stamp for the newest Activity on this Invoice.
      *
      * @param value The new value for newestActivity
      */
-    public void setNewestActivity(Date value) { this.newestActivity = value; }
+    public void setNewestActivity(String value) { this.newestActivity = value; }
     /**
      * The number of days this Invoice is past due.
      *

--- a/src/main/java/io/lockstep/api/models/AttachmentHeaderInfoModel.java
+++ b/src/main/java/io/lockstep/api/models/AttachmentHeaderInfoModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/AttachmentModel.java
+++ b/src/main/java/io/lockstep/api/models/AttachmentModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Represents a user uploaded attachment
@@ -34,7 +33,7 @@ public class AttachmentModel
     private String originAttachmentId;
     private Boolean viewInternal;
     private Boolean viewExternal;
-    private Date created;
+    private String created;
     private String createdUserId;
 
     /**
@@ -180,13 +179,13 @@ public class AttachmentModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date the attachment was created
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * Id of the user who made the file
      *

--- a/src/main/java/io/lockstep/api/models/BulkCurrencyConversionModel.java
+++ b/src/main/java/io/lockstep/api/models/BulkCurrencyConversionModel.java
@@ -9,21 +9,20 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Input format used for bulk conversion route
  */
 public class BulkCurrencyConversionModel
 {
-    private Date date;
+    private String date;
     private String sourceCurrency;
 
     /**
@@ -31,13 +30,13 @@ public class BulkCurrencyConversionModel
      *
      * @return The field date
      */
-    public Date getDate() { return this.date; }
+    public String getDate() { return this.date; }
     /**
      * The date for the currency rate
      *
      * @param value The new value for date
      */
-    public void setDate(Date value) { this.date = value; }
+    public void setDate(String value) { this.date = value; }
     /**
      * The currency code This will be validated by the /api/v1/currencies data set
      *

--- a/src/main/java/io/lockstep/api/models/CashflowReportModel.java
+++ b/src/main/java/io/lockstep/api/models/CashflowReportModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/CodeDefinitionModel.java
+++ b/src/main/java/io/lockstep/api/models/CodeDefinitionModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Represents a Code Definition.  Codes can be used as shortened, human readable strings.
@@ -29,9 +28,9 @@ public class CodeDefinitionModel
     private String codeType;
     private String code;
     private String codeDescription;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
 
     /**
@@ -107,13 +106,13 @@ public class CodeDefinitionModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date that the Code Definition was created
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The ID of the user who created the Code Definition
      *
@@ -131,13 +130,13 @@ public class CodeDefinitionModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * The date the Code Definition was last modified
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The ID of the user who last modified the Code Definition
      *

--- a/src/main/java/io/lockstep/api/models/CompanyModel.java
+++ b/src/main/java/io/lockstep/api/models/CompanyModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * A Company represents a customer, a vendor, or a company within the organization of the account holder.
@@ -48,9 +47,9 @@ public class CompanyModel
     private String country;
     private String phoneNumber;
     private String faxNumber;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
     private String modifiedUserName;
     private String taxId;
@@ -387,13 +386,13 @@ public class CompanyModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date this company was created
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The ID of the user who created this company
      *
@@ -411,13 +410,13 @@ public class CompanyModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * The date this company was last modified
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The ID of the user who last modified this company
      *

--- a/src/main/java/io/lockstep/api/models/ConnectorInfoModel.java
+++ b/src/main/java/io/lockstep/api/models/ConnectorInfoModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/ContactModel.java
+++ b/src/main/java/io/lockstep/api/models/ContactModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * A Contact contains information about a person or role within a Company.
@@ -47,9 +46,9 @@ public class ContactModel
     private Boolean isActive;
     private String webpageUrl;
     private String pictureUrl;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
     private String appEnrollmentId;
     private NoteModel[] notes;
@@ -338,13 +337,13 @@ public class ContactModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date on which this record was created.
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The ID of the user who created this contact.
      *
@@ -362,13 +361,13 @@ public class ContactModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * The date on which this record was last modified.
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The ID of the user who last modified this contact.
      *

--- a/src/main/java/io/lockstep/api/models/CountryModel.java
+++ b/src/main/java/io/lockstep/api/models/CountryModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/CreditMemoAppliedModel.java
+++ b/src/main/java/io/lockstep/api/models/CreditMemoAppliedModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Credit Memos reflect credits granted to a customer for various reasons, such as discounts or refunds.
@@ -33,11 +32,11 @@ public class CreditMemoAppliedModel
     private String creditMemoInvoiceId;
     private String erpKey;
     private Integer entryNumber;
-    private Date applyToInvoiceDate;
+    private String applyToInvoiceDate;
     private Double creditMemoAppliedAmount;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
     private String appEnrollmentId;
     private AttachmentModel[] attachments;
@@ -146,13 +145,13 @@ public class CreditMemoAppliedModel
      *
      * @return The field applyToInvoiceDate
      */
-    public Date getApplyToInvoiceDate() { return this.applyToInvoiceDate; }
+    public String getApplyToInvoiceDate() { return this.applyToInvoiceDate; }
     /**
      * Date payment applied to credit memo.
      *
      * @param value The new value for applyToInvoiceDate
      */
-    public void setApplyToInvoiceDate(Date value) { this.applyToInvoiceDate = value; }
+    public void setApplyToInvoiceDate(String value) { this.applyToInvoiceDate = value; }
     /**
      * Amount applied to credit memo.
      *
@@ -170,13 +169,13 @@ public class CreditMemoAppliedModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * Date credit memo applied record was created.
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The id of the user who created this applied credit memo.
      *
@@ -194,13 +193,13 @@ public class CreditMemoAppliedModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * Date credit memo applied record was modified.
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The id of the user who modified this applied credit memo.
      *

--- a/src/main/java/io/lockstep/api/models/CreditMemoInvoiceModel.java
+++ b/src/main/java/io/lockstep/api/models/CreditMemoInvoiceModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Contains information about a credit memo invoice
@@ -27,7 +26,7 @@ public class CreditMemoInvoiceModel
     private String creditMemoAppliedId;
     private String invoiceId;
     private String creditMemoInvoiceId;
-    private Date applyToInvoiceDate;
+    private String applyToInvoiceDate;
     private Double creditMemoAppliedAmount;
     private String referenceCode;
     private String companyId;
@@ -97,13 +96,13 @@ public class CreditMemoInvoiceModel
      *
      * @return The field applyToInvoiceDate
      */
-    public Date getApplyToInvoiceDate() { return this.applyToInvoiceDate; }
+    public String getApplyToInvoiceDate() { return this.applyToInvoiceDate; }
     /**
      * Date invoice applied to credit memo.
      *
      * @param value The new value for applyToInvoiceDate
      */
-    public void setApplyToInvoiceDate(Date value) { this.applyToInvoiceDate = value; }
+    public void setApplyToInvoiceDate(String value) { this.applyToInvoiceDate = value; }
     /**
      * Amount applied to credit memo.
      *

--- a/src/main/java/io/lockstep/api/models/CurrencyModel.java
+++ b/src/main/java/io/lockstep/api/models/CurrencyModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/CurrencyRateModel.java
+++ b/src/main/java/io/lockstep/api/models/CurrencyRateModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Represents a currency rate for specific currencies and date
@@ -25,7 +24,7 @@ public class CurrencyRateModel
 {
     private String sourceCurrency;
     private String destinationCurrency;
-    private Date date;
+    private String date;
     private Double currencyRate;
 
     /**
@@ -57,13 +56,13 @@ public class CurrencyRateModel
      *
      * @return The field date
      */
-    public Date getDate() { return this.date; }
+    public String getDate() { return this.date; }
     /**
      * The date for the currency rate
      *
      * @param value The new value for date
      */
-    public void setDate(Date value) { this.date = value; }
+    public void setDate(String value) { this.date = value; }
     /**
      * The currency rate value
      *

--- a/src/main/java/io/lockstep/api/models/CustomFieldDefinitionModel.java
+++ b/src/main/java/io/lockstep/api/models/CustomFieldDefinitionModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * A Custom Field represents metadata added to an object within the Lockstep Platform.  Lockstep provides a
@@ -35,9 +34,9 @@ public class CustomFieldDefinitionModel
     private String customFieldLabel;
     private String dataType;
     private Integer sortOrder;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
     private String appEnrollmentId;
 
@@ -138,13 +137,13 @@ public class CustomFieldDefinitionModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * Date created
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * Id of user who created this definition
      *
@@ -162,13 +161,13 @@ public class CustomFieldDefinitionModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * Date modified
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * Id of user who modified this definition
      *

--- a/src/main/java/io/lockstep/api/models/CustomFieldValueModel.java
+++ b/src/main/java/io/lockstep/api/models/CustomFieldValueModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * A Custom Field represents metadata added to an object within the Lockstep Platform.  Lockstep provides a
@@ -33,9 +32,9 @@ public class CustomFieldValueModel
     private String recordKey;
     private String stringValue;
     private Double numericValue;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
     private String appEnrollmentId;
     private CustomFieldDefinitionModel customFieldDefinition;
@@ -113,13 +112,13 @@ public class CustomFieldValueModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * Date created
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * Id of user who created this value
      *
@@ -137,13 +136,13 @@ public class CustomFieldValueModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * Date modified
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * Id of user who modified this value
      *

--- a/src/main/java/io/lockstep/api/models/CustomerDetailsModel.java
+++ b/src/main/java/io/lockstep/api/models/CustomerDetailsModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/CustomerDetailsPaymentModel.java
+++ b/src/main/java/io/lockstep/api/models/CustomerDetailsPaymentModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Customer payment collected information
@@ -31,7 +30,7 @@ public class CustomerDetailsPaymentModel
     private String invoiceTypeCode;
     private String invoiceReferenceCode;
     private Double invoiceTotalAmount;
-    private Date paymentDate;
+    private String paymentDate;
     private Double paymentAmount;
 
     /**
@@ -141,13 +140,13 @@ public class CustomerDetailsPaymentModel
      *
      * @return The field paymentDate
      */
-    public Date getPaymentDate() { return this.paymentDate; }
+    public String getPaymentDate() { return this.paymentDate; }
     /**
      * Date payment placed
      *
      * @param value The new value for paymentDate
      */
-    public void setPaymentDate(Date value) { this.paymentDate = value; }
+    public void setPaymentDate(String value) { this.paymentDate = value; }
     /**
      * Amount payment was made for
      *

--- a/src/main/java/io/lockstep/api/models/CustomerSummaryModel.java
+++ b/src/main/java/io/lockstep/api/models/CustomerSummaryModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Contains summarized data for a customer
@@ -37,7 +36,7 @@ public class CustomerSummaryModel
     private Double unappliedPayments;
     private Double percentOfTotalAr;
     private Double dso;
-    private Date newestActivity;
+    private String newestActivity;
 
     /**
      * The GroupKey uniquely identifies a single Lockstep Platform account.  All records for this
@@ -218,11 +217,11 @@ public class CustomerSummaryModel
      *
      * @return The field newestActivity
      */
-    public Date getNewestActivity() { return this.newestActivity; }
+    public String getNewestActivity() { return this.newestActivity; }
     /**
      * The date stamp for the newest Activity on this Customer.
      *
      * @param value The new value for newestActivity
      */
-    public void setNewestActivity(Date value) { this.newestActivity = value; }
+    public void setNewestActivity(String value) { this.newestActivity = value; }
 };

--- a/src/main/java/io/lockstep/api/models/DailySalesOutstandingReportModel.java
+++ b/src/main/java/io/lockstep/api/models/DailySalesOutstandingReportModel.java
@@ -9,21 +9,20 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Represents the daily sales outstanding report
  */
 public class DailySalesOutstandingReportModel
 {
-    private Date timeframe;
+    private String timeframe;
     private Integer invoiceCount;
     private Double dailySalesOutstanding;
 
@@ -32,13 +31,13 @@ public class DailySalesOutstandingReportModel
      *
      * @return The field timeframe
      */
-    public Date getTimeframe() { return this.timeframe; }
+    public String getTimeframe() { return this.timeframe; }
     /**
      * Timeframe (month) the daily sales outstanding values are associated with
      *
      * @param value The new value for timeframe
      */
-    public void setTimeframe(Date value) { this.timeframe = value; }
+    public void setTimeframe(String value) { this.timeframe = value; }
     /**
      * Number of invoices the average daily sales outstanding is calculated on
      *

--- a/src/main/java/io/lockstep/api/models/DeveloperAccountSubmitModel.java
+++ b/src/main/java/io/lockstep/api/models/DeveloperAccountSubmitModel.java
@@ -1,0 +1,65 @@
+
+/**
+ * Lockstep Software Development Kit for Java
+ *
+ * (c) 2021-2022 Lockstep, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     Ted Spence <tspence@lockstep.io>
+ * @copyright  2021-2022 Lockstep, Inc.
+ * @version    2022.3
+ * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
+ */
+
+
+package io.lockstep.api.models;
+
+
+/**
+ * Model containing information to create a new developer account.
+ */
+public class DeveloperAccountSubmitModel
+{
+    private String name;
+    private String email;
+    private String companyName;
+
+    /**
+     * The name of the developer.
+     *
+     * @return The field name
+     */
+    public String getName() { return this.name; }
+    /**
+     * The name of the developer.
+     *
+     * @param value The new value for name
+     */
+    public void setName(String value) { this.name = value; }
+    /**
+     * The email address of the developer.
+     *
+     * @return The field email
+     */
+    public String getEmail() { return this.email; }
+    /**
+     * The email address of the developer.
+     *
+     * @param value The new value for email
+     */
+    public void setEmail(String value) { this.email = value; }
+    /**
+     * The company name of the developer.
+     *
+     * @return The field companyName
+     */
+    public String getCompanyName() { return this.companyName; }
+    /**
+     * The company name of the developer.
+     *
+     * @param value The new value for companyName
+     */
+    public void setCompanyName(String value) { this.companyName = value; }
+};

--- a/src/main/java/io/lockstep/api/models/EmailModel.java
+++ b/src/main/java/io/lockstep/api/models/EmailModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * An Email represents a communication sent from one company to another.  The creator of the email is identified
@@ -35,23 +34,23 @@ public class EmailModel
     private String emailCC;
     private String emailSubject;
     private String emailBody;
-    private Date sentDate;
+    private String sentDate;
     private Boolean isUnread;
     private Boolean isPriority;
     private Boolean isSpam;
-    private Date created;
+    private String created;
     private String createdUserId;
     private Boolean toBeSent;
     private String customerId;
-    private Date receivedTimeStamp;
-    private Date openedTimestamp;
+    private String receivedTimeStamp;
+    private String openedTimestamp;
     private Integer viewCount;
     private String appEnrollmentId;
     private String externalEmailId;
     private String externalThreadId;
     private String emailBcc;
     private String sendType;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
     private String responseOriginId;
     private EmailModel responseOrigin;
@@ -181,13 +180,13 @@ public class EmailModel
      *
      * @return The field sentDate
      */
-    public Date getSentDate() { return this.sentDate; }
+    public String getSentDate() { return this.sentDate; }
     /**
      * The date on which this email was sent.
      *
      * @param value The new value for sentDate
      */
-    public void setSentDate(Date value) { this.sentDate = value; }
+    public void setSentDate(String value) { this.sentDate = value; }
     /**
      * A status flag indicating if this email is unread.
      *
@@ -229,13 +228,13 @@ public class EmailModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date on which this email was created.
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The ID number of the user who created this email.
      *
@@ -277,25 +276,25 @@ public class EmailModel
      *
      * @return The field receivedTimeStamp
      */
-    public Date getReceivedTimeStamp() { return this.receivedTimeStamp; }
+    public String getReceivedTimeStamp() { return this.receivedTimeStamp; }
     /**
      * The date on which this email was received.
      *
      * @param value The new value for receivedTimeStamp
      */
-    public void setReceivedTimeStamp(Date value) { this.receivedTimeStamp = value; }
+    public void setReceivedTimeStamp(String value) { this.receivedTimeStamp = value; }
     /**
      * The date on which this email was opened.
      *
      * @return The field openedTimestamp
      */
-    public Date getOpenedTimestamp() { return this.openedTimestamp; }
+    public String getOpenedTimestamp() { return this.openedTimestamp; }
     /**
      * The date on which this email was opened.
      *
      * @param value The new value for openedTimestamp
      */
-    public void setOpenedTimestamp(Date value) { this.openedTimestamp = value; }
+    public void setOpenedTimestamp(String value) { this.openedTimestamp = value; }
     /**
      * The number of times this email was viewed.
      *
@@ -374,14 +373,14 @@ public class EmailModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * The date on which this email was modified.
      * Email modification should only be done by internal services.
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The ID of the user who modified this email.
      * Email modification should only be done by internal services.

--- a/src/main/java/io/lockstep/api/models/ErpInfoDataModel.java
+++ b/src/main/java/io/lockstep/api/models/ErpInfoDataModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/ErpInfoModel.java
+++ b/src/main/java/io/lockstep/api/models/ErpInfoModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/ErpModel.java
+++ b/src/main/java/io/lockstep/api/models/ErpModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/InviteDataModel.java
+++ b/src/main/java/io/lockstep/api/models/InviteDataModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/InviteModel.java
+++ b/src/main/java/io/lockstep/api/models/InviteModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/InviteSubmitModel.java
+++ b/src/main/java/io/lockstep/api/models/InviteSubmitModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/InvoiceAddressModel.java
+++ b/src/main/java/io/lockstep/api/models/InvoiceAddressModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Represents a single address for an invoice
@@ -35,9 +34,9 @@ public class InvoiceAddressModel
     private String country;
     private Float latitude;
     private Float longitude;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
 
     /**
@@ -197,13 +196,13 @@ public class InvoiceAddressModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date on which this address record was created.
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The ID number of the user who created this address.
      *
@@ -221,13 +220,13 @@ public class InvoiceAddressModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * The date on which this address record was last modified.
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The ID number of the user who most recently modified this address.
      *

--- a/src/main/java/io/lockstep/api/models/InvoiceHistoryModel.java
+++ b/src/main/java/io/lockstep/api/models/InvoiceHistoryModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * An Invoice represents a bill sent from one company to another.  The Lockstep Platform tracks changes to
@@ -44,18 +43,18 @@ public class InvoiceHistoryModel
     private Double salesTaxAmount;
     private Double discountAmount;
     private Double outstandingBalanceAmount;
-    private Date invoiceDate;
-    private Date discountDate;
-    private Date postedDate;
-    private Date invoiceClosedDate;
-    private Date paymentDueDate;
-    private Date importedDate;
+    private String invoiceDate;
+    private String discountDate;
+    private String postedDate;
+    private String invoiceClosedDate;
+    private String paymentDueDate;
+    private String importedDate;
     private String primaryOriginAddressId;
     private String primaryBillToAddressId;
     private String primaryShipToAddressId;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
 
     /**
@@ -317,75 +316,75 @@ public class InvoiceHistoryModel
      *
      * @return The field invoiceDate
      */
-    public Date getInvoiceDate() { return this.invoiceDate; }
+    public String getInvoiceDate() { return this.invoiceDate; }
     /**
      * The reporting date for this invoice.
      *
      * @param value The new value for invoiceDate
      */
-    public void setInvoiceDate(Date value) { this.invoiceDate = value; }
+    public void setInvoiceDate(String value) { this.invoiceDate = value; }
     /**
      * The date when discounts were adjusted for this invoice.
      *
      * @return The field discountDate
      */
-    public Date getDiscountDate() { return this.discountDate; }
+    public String getDiscountDate() { return this.discountDate; }
     /**
      * The date when discounts were adjusted for this invoice.
      *
      * @param value The new value for discountDate
      */
-    public void setDiscountDate(Date value) { this.discountDate = value; }
+    public void setDiscountDate(String value) { this.discountDate = value; }
     /**
      * The date when this invoice posted to the company's general ledger.
      *
      * @return The field postedDate
      */
-    public Date getPostedDate() { return this.postedDate; }
+    public String getPostedDate() { return this.postedDate; }
     /**
      * The date when this invoice posted to the company's general ledger.
      *
      * @param value The new value for postedDate
      */
-    public void setPostedDate(Date value) { this.postedDate = value; }
+    public void setPostedDate(String value) { this.postedDate = value; }
     /**
      * The date when the invoice was closed and finalized after completion of all payments and delivery of all products and
      * services.
      *
      * @return The field invoiceClosedDate
      */
-    public Date getInvoiceClosedDate() { return this.invoiceClosedDate; }
+    public String getInvoiceClosedDate() { return this.invoiceClosedDate; }
     /**
      * The date when the invoice was closed and finalized after completion of all payments and delivery of all products and
      * services.
      *
      * @param value The new value for invoiceClosedDate
      */
-    public void setInvoiceClosedDate(Date value) { this.invoiceClosedDate = value; }
+    public void setInvoiceClosedDate(String value) { this.invoiceClosedDate = value; }
     /**
      * The date when the remaining outstanding balance is due.
      *
      * @return The field paymentDueDate
      */
-    public Date getPaymentDueDate() { return this.paymentDueDate; }
+    public String getPaymentDueDate() { return this.paymentDueDate; }
     /**
      * The date when the remaining outstanding balance is due.
      *
      * @param value The new value for paymentDueDate
      */
-    public void setPaymentDueDate(Date value) { this.paymentDueDate = value; }
+    public void setPaymentDueDate(String value) { this.paymentDueDate = value; }
     /**
      * The date and time when this record was imported from the user's ERP or accounting system.
      *
      * @return The field importedDate
      */
-    public Date getImportedDate() { return this.importedDate; }
+    public String getImportedDate() { return this.importedDate; }
     /**
      * The date and time when this record was imported from the user's ERP or accounting system.
      *
      * @param value The new value for importedDate
      */
-    public void setImportedDate(Date value) { this.importedDate = value; }
+    public void setImportedDate(String value) { this.importedDate = value; }
     /**
      * The ID number of the invoice's origination address
      *
@@ -427,13 +426,13 @@ public class InvoiceHistoryModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date on which this invoice record was created.
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The ID number of the user who created this invoice.
      *
@@ -451,13 +450,13 @@ public class InvoiceHistoryModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * The date on which this invoice record was last modified.
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The ID number of the user who most recently modified this invoice.
      *

--- a/src/main/java/io/lockstep/api/models/InvoiceLineModel.java
+++ b/src/main/java/io/lockstep/api/models/InvoiceLineModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Represents a line in an invoice
@@ -37,13 +36,13 @@ public class InvoiceLineModel
     private Double quantityReceived;
     private Double totalAmount;
     private String exemptionCode;
-    private Date reportingDate;
+    private String reportingDate;
     private String overrideOriginAddressId;
     private String overrideBillToAddressId;
     private String overrideShipToAddressId;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
     private String appEnrollmentId;
     private NoteModel[] notes;
@@ -253,14 +252,14 @@ public class InvoiceLineModel
      *
      * @return The field reportingDate
      */
-    public Date getReportingDate() { return this.reportingDate; }
+    public String getReportingDate() { return this.reportingDate; }
     /**
      * If null, the products specified on this line were delivered on the same date as all other lines.
      * If not null, this line was delivered or finalized on a different date than the overall invoice.
      *
      * @param value The new value for reportingDate
      */
-    public void setReportingDate(Date value) { this.reportingDate = value; }
+    public void setReportingDate(String value) { this.reportingDate = value; }
     /**
      * An optional ID number for the line's origin address.
      *
@@ -302,13 +301,13 @@ public class InvoiceLineModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date on which this line was created.
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The ID number of the user who created this line.
      *
@@ -326,13 +325,13 @@ public class InvoiceLineModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * The date on which this line was last modified.
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The ID number of the user who most recently modified this line.
      *

--- a/src/main/java/io/lockstep/api/models/InvoiceModel.java
+++ b/src/main/java/io/lockstep/api/models/InvoiceModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * An Invoice represents a bill sent from one company to another.  The creator of the invoice is identified
@@ -46,18 +45,18 @@ public class InvoiceModel
     private Double salesTaxAmount;
     private Double discountAmount;
     private Double outstandingBalanceAmount;
-    private Date invoiceDate;
-    private Date discountDate;
-    private Date postedDate;
-    private Date invoiceClosedDate;
-    private Date paymentDueDate;
-    private Date importedDate;
+    private String invoiceDate;
+    private String discountDate;
+    private String postedDate;
+    private String invoiceClosedDate;
+    private String paymentDueDate;
+    private String importedDate;
     private String primaryOriginAddressId;
     private String primaryBillToAddressId;
     private String primaryShipToAddressId;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
     private String appEnrollmentId;
     private Boolean isVoided;
@@ -322,75 +321,75 @@ public class InvoiceModel
      *
      * @return The field invoiceDate
      */
-    public Date getInvoiceDate() { return this.invoiceDate; }
+    public String getInvoiceDate() { return this.invoiceDate; }
     /**
      * The reporting date for this invoice.
      *
      * @param value The new value for invoiceDate
      */
-    public void setInvoiceDate(Date value) { this.invoiceDate = value; }
+    public void setInvoiceDate(String value) { this.invoiceDate = value; }
     /**
      * The date when discounts were adjusted for this invoice.
      *
      * @return The field discountDate
      */
-    public Date getDiscountDate() { return this.discountDate; }
+    public String getDiscountDate() { return this.discountDate; }
     /**
      * The date when discounts were adjusted for this invoice.
      *
      * @param value The new value for discountDate
      */
-    public void setDiscountDate(Date value) { this.discountDate = value; }
+    public void setDiscountDate(String value) { this.discountDate = value; }
     /**
      * The date when this invoice posted to the company's general ledger.
      *
      * @return The field postedDate
      */
-    public Date getPostedDate() { return this.postedDate; }
+    public String getPostedDate() { return this.postedDate; }
     /**
      * The date when this invoice posted to the company's general ledger.
      *
      * @param value The new value for postedDate
      */
-    public void setPostedDate(Date value) { this.postedDate = value; }
+    public void setPostedDate(String value) { this.postedDate = value; }
     /**
      * The date when the invoice was closed and finalized after completion of all payments and delivery of all products and
      * services.
      *
      * @return The field invoiceClosedDate
      */
-    public Date getInvoiceClosedDate() { return this.invoiceClosedDate; }
+    public String getInvoiceClosedDate() { return this.invoiceClosedDate; }
     /**
      * The date when the invoice was closed and finalized after completion of all payments and delivery of all products and
      * services.
      *
      * @param value The new value for invoiceClosedDate
      */
-    public void setInvoiceClosedDate(Date value) { this.invoiceClosedDate = value; }
+    public void setInvoiceClosedDate(String value) { this.invoiceClosedDate = value; }
     /**
      * The date when the remaining outstanding balance is due.
      *
      * @return The field paymentDueDate
      */
-    public Date getPaymentDueDate() { return this.paymentDueDate; }
+    public String getPaymentDueDate() { return this.paymentDueDate; }
     /**
      * The date when the remaining outstanding balance is due.
      *
      * @param value The new value for paymentDueDate
      */
-    public void setPaymentDueDate(Date value) { this.paymentDueDate = value; }
+    public void setPaymentDueDate(String value) { this.paymentDueDate = value; }
     /**
      * The date and time when this record was imported from the user's ERP or accounting system.
      *
      * @return The field importedDate
      */
-    public Date getImportedDate() { return this.importedDate; }
+    public String getImportedDate() { return this.importedDate; }
     /**
      * The date and time when this record was imported from the user's ERP or accounting system.
      *
      * @param value The new value for importedDate
      */
-    public void setImportedDate(Date value) { this.importedDate = value; }
+    public void setImportedDate(String value) { this.importedDate = value; }
     /**
      * The ID number of the invoice's origination address
      *
@@ -432,13 +431,13 @@ public class InvoiceModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date on which this address record was created.
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The ID number of the user who created this address.
      *
@@ -456,13 +455,13 @@ public class InvoiceModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * The date on which this address record was last modified.
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The ID number of the user who most recently modified this address.
      *

--- a/src/main/java/io/lockstep/api/models/InvoicePaymentDetailModel.java
+++ b/src/main/java/io/lockstep/api/models/InvoicePaymentDetailModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * View to return Payment Detail information for a given Invoice record.
@@ -27,7 +26,7 @@ public class InvoicePaymentDetailModel
     private String paymentAppliedId;
     private String invoiceId;
     private String paymentId;
-    private Date applyToInvoiceDate;
+    private String applyToInvoiceDate;
     private Double paymentAppliedAmount;
     private String referenceCode;
     private String companyId;
@@ -93,13 +92,13 @@ public class InvoicePaymentDetailModel
      *
      * @return The field applyToInvoiceDate
      */
-    public Date getApplyToInvoiceDate() { return this.applyToInvoiceDate; }
+    public String getApplyToInvoiceDate() { return this.applyToInvoiceDate; }
     /**
      * Date Payment applied to Invoice.
      *
      * @param value The new value for applyToInvoiceDate
      */
-    public void setApplyToInvoiceDate(Date value) { this.applyToInvoiceDate = value; }
+    public void setApplyToInvoiceDate(String value) { this.applyToInvoiceDate = value; }
     /**
      * Amount applied to Invoice.
      *

--- a/src/main/java/io/lockstep/api/models/InvoiceSummaryModel.java
+++ b/src/main/java/io/lockstep/api/models/InvoiceSummaryModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Contains summarized data for an invoice
@@ -27,14 +26,14 @@ public class InvoiceSummaryModel
     private String customerId;
     private String invoiceId;
     private String invoiceNumber;
-    private Date invoiceDate;
+    private String invoiceDate;
     private String customerName;
     private String status;
-    private Date paymentDueDate;
+    private String paymentDueDate;
     private Double invoiceAmount;
     private Double outstandingBalance;
     private String invoiceTypeCode;
-    private Date newestActivity;
+    private String newestActivity;
     private Integer daysPastDue;
     private String[] paymentNumbers;
     private String[] paymentIds;
@@ -100,13 +99,13 @@ public class InvoiceSummaryModel
      *
      * @return The field invoiceDate
      */
-    public Date getInvoiceDate() { return this.invoiceDate; }
+    public String getInvoiceDate() { return this.invoiceDate; }
     /**
      * The reporting date for this invoice.
      *
      * @param value The new value for invoiceDate
      */
-    public void setInvoiceDate(Date value) { this.invoiceDate = value; }
+    public void setInvoiceDate(String value) { this.invoiceDate = value; }
     /**
      * The name of the counterparty for the invoice, for example, a customer or vendor.
      *
@@ -136,13 +135,13 @@ public class InvoiceSummaryModel
      *
      * @return The field paymentDueDate
      */
-    public Date getPaymentDueDate() { return this.paymentDueDate; }
+    public String getPaymentDueDate() { return this.paymentDueDate; }
     /**
      * The due date of the invoice.
      *
      * @param value The new value for paymentDueDate
      */
-    public void setPaymentDueDate(Date value) { this.paymentDueDate = value; }
+    public void setPaymentDueDate(String value) { this.paymentDueDate = value; }
     /**
      * The total amount of the Invoice.
      *
@@ -184,13 +183,13 @@ public class InvoiceSummaryModel
      *
      * @return The field newestActivity
      */
-    public Date getNewestActivity() { return this.newestActivity; }
+    public String getNewestActivity() { return this.newestActivity; }
     /**
      * The date stamp for the newest Activity on this Invoice.
      *
      * @param value The new value for newestActivity
      */
-    public void setNewestActivity(Date value) { this.newestActivity = value; }
+    public void setNewestActivity(String value) { this.newestActivity = value; }
     /**
      * The number of days this Invoice is past due.
      *

--- a/src/main/java/io/lockstep/api/models/LeadModel.java
+++ b/src/main/java/io/lockstep/api/models/LeadModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/NoteModel.java
+++ b/src/main/java/io/lockstep/api/models/NoteModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * A note is a customizable text string that can be attached to various account attributes
@@ -35,10 +34,11 @@ public class NoteModel
     private String noteText;
     private String noteType;
     private Boolean isArchived;
-    private Date created;
+    private String created;
     private String createdUserId;
     private String createdUserName;
     private String appEnrollmentId;
+    private String recipientName;
 
     /**
      * The unique ID of this record, automatically assigned by Lockstep when this record is
@@ -137,13 +137,13 @@ public class NoteModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date the note was created
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The ID of the user who created the note
      *
@@ -180,4 +180,16 @@ public class NoteModel
      * @param value The new value for appEnrollmentId
      */
     public void setAppEnrollmentId(String value) { this.appEnrollmentId = value; }
+    /**
+     * The person to whom this note is intended for.
+     *
+     * @return The field recipientName
+     */
+    public String getRecipientName() { return this.recipientName; }
+    /**
+     * The person to whom this note is intended for.
+     *
+     * @param value The new value for recipientName
+     */
+    public void setRecipientName(String value) { this.recipientName = value; }
 };

--- a/src/main/java/io/lockstep/api/models/PaymentAppliedModel.java
+++ b/src/main/java/io/lockstep/api/models/PaymentAppliedModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * A Payment Application is created by a business who receives a Payment from a customer.  A customer may make
@@ -32,11 +31,11 @@ public class PaymentAppliedModel
     private String paymentId;
     private String erpKey;
     private Integer entryNumber;
-    private Date applyToInvoiceDate;
+    private String applyToInvoiceDate;
     private Double paymentAppliedAmount;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
     private String appEnrollmentId;
     private InvoiceModel invoice;
@@ -142,13 +141,13 @@ public class PaymentAppliedModel
      *
      * @return The field applyToInvoiceDate
      */
-    public Date getApplyToInvoiceDate() { return this.applyToInvoiceDate; }
+    public String getApplyToInvoiceDate() { return this.applyToInvoiceDate; }
     /**
      * Date payment applied to invoice.
      *
      * @param value The new value for applyToInvoiceDate
      */
-    public void setApplyToInvoiceDate(Date value) { this.applyToInvoiceDate = value; }
+    public void setApplyToInvoiceDate(String value) { this.applyToInvoiceDate = value; }
     /**
      * Amount applied to invoice.
      *
@@ -166,13 +165,13 @@ public class PaymentAppliedModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * Date payment applied record was created.
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The id of the user who created this applied payment.
      *
@@ -190,13 +189,13 @@ public class PaymentAppliedModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * Date payment applied record was modified.
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The id of the user who modified this applied payment.
      *

--- a/src/main/java/io/lockstep/api/models/PaymentDetailHeaderModel.java
+++ b/src/main/java/io/lockstep/api/models/PaymentDetailHeaderModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/PaymentDetailModel.java
+++ b/src/main/java/io/lockstep/api/models/PaymentDetailModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Contains detailed information about a Payment.
@@ -34,8 +33,8 @@ public class PaymentDetailModel
     private Double paymentAmount;
     private Double unappliedAmount;
     private String paymentType;
-    private Date paymentDate;
-    private Date postDate;
+    private String paymentDate;
+    private String postDate;
     private String phone;
     private String fax;
     private String address1;
@@ -189,25 +188,25 @@ public class PaymentDetailModel
      *
      * @return The field paymentDate
      */
-    public Date getPaymentDate() { return this.paymentDate; }
+    public String getPaymentDate() { return this.paymentDate; }
     /**
      * The date of this Payment.
      *
      * @param value The new value for paymentDate
      */
-    public void setPaymentDate(Date value) { this.paymentDate = value; }
+    public void setPaymentDate(String value) { this.paymentDate = value; }
     /**
      * Payment post date.
      *
      * @return The field postDate
      */
-    public Date getPostDate() { return this.postDate; }
+    public String getPostDate() { return this.postDate; }
     /**
      * Payment post date.
      *
      * @param value The new value for postDate
      */
-    public void setPostDate(Date value) { this.postDate = value; }
+    public void setPostDate(String value) { this.postDate = value; }
     /**
      * The phone number of the Customer's Primary Contact.
      *

--- a/src/main/java/io/lockstep/api/models/PaymentModel.java
+++ b/src/main/java/io/lockstep/api/models/PaymentModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * A Payment represents money sent from one company to another.  A single payment may contain payments for
@@ -37,15 +36,15 @@ public class PaymentModel
     private String tenderType;
     private Boolean isOpen;
     private String memoText;
-    private Date paymentDate;
-    private Date postDate;
+    private String paymentDate;
+    private String postDate;
     private Double paymentAmount;
     private Double unappliedAmount;
     private String currencyCode;
     private String referenceCode;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
     private String appEnrollmentId;
     private Boolean isVoided;
@@ -181,25 +180,25 @@ public class PaymentModel
      *
      * @return The field paymentDate
      */
-    public Date getPaymentDate() { return this.paymentDate; }
+    public String getPaymentDate() { return this.paymentDate; }
     /**
      * The date of this payment.
      *
      * @param value The new value for paymentDate
      */
-    public void setPaymentDate(Date value) { this.paymentDate = value; }
+    public void setPaymentDate(String value) { this.paymentDate = value; }
     /**
      * Payment post date.
      *
      * @return The field postDate
      */
-    public Date getPostDate() { return this.postDate; }
+    public String getPostDate() { return this.postDate; }
     /**
      * Payment post date.
      *
      * @param value The new value for postDate
      */
-    public void setPostDate(Date value) { this.postDate = value; }
+    public void setPostDate(String value) { this.postDate = value; }
     /**
      * Total amount of this payment.
      *
@@ -253,13 +252,13 @@ public class PaymentModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date on which this record was created.
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The ID of the user who created this payment.
      *
@@ -277,13 +276,13 @@ public class PaymentModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * The date on which this record was last modified.
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The ID of the user who last modified this payment.
      *

--- a/src/main/java/io/lockstep/api/models/PaymentSummaryModel.java
+++ b/src/main/java/io/lockstep/api/models/PaymentSummaryModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Contains summary information for a Payment
@@ -28,7 +27,7 @@ public class PaymentSummaryModel
     private String memoText;
     private String referenceCode;
     private String paymentType;
-    private Date paymentDate;
+    private String paymentDate;
     private Double paymentAmount;
     private Double unappliedAmount;
     private Integer invoiceCount;
@@ -109,13 +108,13 @@ public class PaymentSummaryModel
      *
      * @return The field paymentDate
      */
-    public Date getPaymentDate() { return this.paymentDate; }
+    public String getPaymentDate() { return this.paymentDate; }
     /**
      * The date of this payment.
      *
      * @param value The new value for paymentDate
      */
-    public void setPaymentDate(Date value) { this.paymentDate = value; }
+    public void setPaymentDate(String value) { this.paymentDate = value; }
     /**
      * Total amount of this payment.
      *

--- a/src/main/java/io/lockstep/api/models/ProvisioningFinalizeRequestModel.java
+++ b/src/main/java/io/lockstep/api/models/ProvisioningFinalizeRequestModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/ProvisioningModel.java
+++ b/src/main/java/io/lockstep/api/models/ProvisioningModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/ProvisioningResponseModel.java
+++ b/src/main/java/io/lockstep/api/models/ProvisioningResponseModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/RiskRateModel.java
+++ b/src/main/java/io/lockstep/api/models/RiskRateModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Represents a risk rate calculation for a single month
@@ -24,7 +23,7 @@ import java.util.Date;
 public class RiskRateModel
 {
     private String groupKey;
-    private Date reportPeriod;
+    private String reportPeriod;
     private String invoiceMonthName;
     private Integer totalInvoiceCount;
     private Double totalInvoiceAmount;
@@ -56,13 +55,13 @@ public class RiskRateModel
      *
      * @return The field reportPeriod
      */
-    public Date getReportPeriod() { return this.reportPeriod; }
+    public String getReportPeriod() { return this.reportPeriod; }
     /**
      * The month the risk rate was calculated for
      *
      * @param value The new value for reportPeriod
      */
-    public void setReportPeriod(Date value) { this.reportPeriod = value; }
+    public void setReportPeriod(String value) { this.reportPeriod = value; }
     /**
      * The string name of the month the risk rate was calculated for
      *

--- a/src/main/java/io/lockstep/api/models/StateModel.java
+++ b/src/main/java/io/lockstep/api/models/StateModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/StatusModel.java
+++ b/src/main/java/io/lockstep/api/models/StatusModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Represents the status of a user's credentials
@@ -31,7 +30,7 @@ public class StatusModel
     private Boolean loggedIn;
     private String errorMessage;
     private String[] roles;
-    private Date lastLoggedIn;
+    private String lastLoggedIn;
     private String apiKeyId;
     private String userStatus;
     private String environment;
@@ -139,13 +138,13 @@ public class StatusModel
      *
      * @return The field lastLoggedIn
      */
-    public Date getLastLoggedIn() { return this.lastLoggedIn; }
+    public String getLastLoggedIn() { return this.lastLoggedIn; }
     /**
      * Date and time user has last logged into Azure B2C.
      *
      * @param value The new value for lastLoggedIn
      */
-    public void setLastLoggedIn(Date value) { this.lastLoggedIn = value; }
+    public void setLastLoggedIn(String value) { this.lastLoggedIn = value; }
     /**
      * The id of the API key used to authenticate.
      *

--- a/src/main/java/io/lockstep/api/models/SyncEntityResultModel.java
+++ b/src/main/java/io/lockstep/api/models/SyncEntityResultModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/SyncRequestModel.java
+++ b/src/main/java/io/lockstep/api/models/SyncRequestModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Represents a user request to sync data
@@ -28,8 +27,8 @@ public class SyncRequestModel
     private String statusCode;
     private String processResultMessage;
     private String appEnrollmentId;
-    private Date created;
-    private Date modified;
+    private String created;
+    private String modified;
     private String modifiedUserId;
     private Object details;
 
@@ -106,25 +105,25 @@ public class SyncRequestModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date this sync request was created
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The date this sync request was last modified
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * The date this sync request was last modified
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The ID number of the user who most recently modified this sync request.
      *

--- a/src/main/java/io/lockstep/api/models/SyncSubmitModel.java
+++ b/src/main/java/io/lockstep/api/models/SyncSubmitModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/TransferOwnerModel.java
+++ b/src/main/java/io/lockstep/api/models/TransferOwnerModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/TransferOwnerSubmitModel.java
+++ b/src/main/java/io/lockstep/api/models/TransferOwnerSubmitModel.java
@@ -9,7 +9,7 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 

--- a/src/main/java/io/lockstep/api/models/UserAccountModel.java
+++ b/src/main/java/io/lockstep/api/models/UserAccountModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * A User represents a person who has the ability to authenticate against the Lockstep Platform and use
@@ -32,14 +31,14 @@ public class UserAccountModel
     private String userName;
     private String email;
     private String status;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
     private String modifiedUserName;
     private String b2CUserId;
     private String userRole;
-    private Date inviteSent;
+    private String inviteSent;
     private String phoneNumber;
     private String faxNumber;
     private String title;
@@ -53,7 +52,7 @@ public class UserAccountModel
     private String country;
     private String imageURL;
     private String description;
-    private Date b2CLastLoggedIn;
+    private String b2CLastLoggedIn;
     private String defaultCurrencyCode;
     private NoteModel[] notes;
     private AttachmentModel[] attachments;
@@ -137,13 +136,13 @@ public class UserAccountModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date that the user account was created
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The ID of the user who created the user account
      *
@@ -161,13 +160,13 @@ public class UserAccountModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * The date the user account was last modified
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The ID of the user who last modified the user account
      *
@@ -221,13 +220,13 @@ public class UserAccountModel
      *
      * @return The field inviteSent
      */
-    public Date getInviteSent() { return this.inviteSent; }
+    public String getInviteSent() { return this.inviteSent; }
     /**
      * The date timestamp when the invite was sent to the user.
      *
      * @param value The new value for inviteSent
      */
-    public void setInviteSent(Date value) { this.inviteSent = value; }
+    public void setInviteSent(String value) { this.inviteSent = value; }
     /**
      * The phone number of the user.
      *
@@ -389,13 +388,13 @@ public class UserAccountModel
      *
      * @return The field b2CLastLoggedIn
      */
-    public Date getB2CLastLoggedIn() { return this.b2CLastLoggedIn; }
+    public String getB2CLastLoggedIn() { return this.b2CLastLoggedIn; }
     /**
      * Last date time user logged into Azure B2C.
      *
      * @param value The new value for b2CLastLoggedIn
      */
-    public void setB2CLastLoggedIn(Date value) { this.b2CLastLoggedIn = value; }
+    public void setB2CLastLoggedIn(String value) { this.b2CLastLoggedIn = value; }
     /**
      * The default currency code used by this user entity.  This value can be overridden
      * for invoices in a different currency code.

--- a/src/main/java/io/lockstep/api/models/UserRoleModel.java
+++ b/src/main/java/io/lockstep/api/models/UserRoleModel.java
@@ -9,14 +9,13 @@
  *
  * @author     Ted Spence <tspence@lockstep.io>
  * @copyright  2021-2022 Lockstep, Inc.
- * @version    2022.2
+ * @version    2022.3
  * @link       https://github.com/Lockstep-Network/lockstep-sdk-java
  */
 
 
 package io.lockstep.api.models;
 
-import java.util.Date;
 
 /**
  * Represents a role for a user
@@ -26,9 +25,9 @@ public class UserRoleModel
     private String userRoleId;
     private String groupKey;
     private String userRoleName;
-    private Date created;
+    private String created;
     private String createdUserId;
-    private Date modified;
+    private String modified;
     private String modifiedUserId;
 
     /**
@@ -80,13 +79,13 @@ public class UserRoleModel
      *
      * @return The field created
      */
-    public Date getCreated() { return this.created; }
+    public String getCreated() { return this.created; }
     /**
      * The date that the user role was created
      *
      * @param value The new value for created
      */
-    public void setCreated(Date value) { this.created = value; }
+    public void setCreated(String value) { this.created = value; }
     /**
      * The ID of the user who created the user role
      *
@@ -104,13 +103,13 @@ public class UserRoleModel
      *
      * @return The field modified
      */
-    public Date getModified() { return this.modified; }
+    public String getModified() { return this.modified; }
     /**
      * The date the user role was last modified
      *
      * @param value The new value for modified
      */
-    public void setModified(Date value) { this.modified = value; }
+    public void setModified(String value) { this.modified = value; }
     /**
      * The ID of the user who last modified the user role
      *


### PR DESCRIPTION
So, in the accounting world, many of our dates are *dates*.  They aren't date-time stamps and they don't have time zones.

We want to avoid problems with parsing time zones; so let's update our Java classes to instead use Strings rather than Date objects to handle dates.