### PR TITLE
Add `mvn verify` for pull requests

### DIFF
--- a/.github/workflows/maven-central-repo-publish.yml
+++ b/.github/workflows/maven-central-repo-publish.yml
@@ -31,7 +31,11 @@ jobs:
         server-password: OSSRH_PASSWORD
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
-        
+
+    - name: Verify with Maven
+      if: github.event_name == 'pull_request'
+      run: mvn -B clean verify
+
     - name: Build with Maven
       run: mvn -B compile --file pom.xml
 


### PR DESCRIPTION
Currently, `mvn verify` is set to run in the workflow only when a pull request is created. The next step would be to setup branch policies so that we are not able to merge to main unless all checks have passed.

Under `Settings` > `Branches` > `add rule`:

![image](https://user-images.githubusercontent.com/36486525/163056274-0e121fc5-74f0-4150-b15b-d95c64d36e07.png)

Testing was done in a separate repo ([source](https://github.com/nicoleajoy/github-actions-example)).